### PR TITLE
Bugfix/floating precision

### DIFF
--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -67,20 +67,20 @@ const round = round(2)
 ### Calc floating point precision
 
 ```typescript
-import {calcFloatingPrecision} from "utils/numbers";
+import {calcDecimalPlace} from "utils/numbers";
 
 const value = 0.000123
-const precision = calcFloatingPrecision(value, 3)
+const precision = calcDecimalPlace(value, 3)
 // precision == 6
 ```
 
 Combined example
 
 ```typescript
-import {round, calcFloatingPrecision} from "utils/numbers";
+import {round, calcDecimalPlace} from "utils/numbers";
 
 function financialRound(value: number) {
-  return round(value, calcFloatingPrecision(value, 3));
+  return round(value, calcDecimalPlace(value, 3));
 }
 ```
 

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -75,23 +75,38 @@ export function round(value:number, precision:number) {
     return Math.round(value * factorOfTen) / factorOfTen;
 }
 
+
+/**
+ * @deprecated Use {@link calcDecimalPlace()} instead
+ * @param value
+ * @param minPrecision
+ */
+export function calcFloatingPrecision(value:number, minPrecision:number) {
+    return calcDecimalPlace(value, minPrecision)
+}
+
 /**
  * Calculates a floating precision if the value is smaller than the requested precision
  * @param value The given value
  * @param minPrecision Minimal precision value
  * @return Fitting precision
  */
-export function calcFloatingPrecision(value:number, minPrecision:number) {
+export function calcDecimalPlace(value: number, minPrecision: number) {
     if (minPrecision <= 0) {
         return 0
     }
-    let realPrecision = minPrecision;
+    let realPrecision = 1;
     const absValue = Math.abs(value);
-    while (absValue > 0 && absValue < 1/Math.pow(10, Math.max(realPrecision-1, 1))) {
-        realPrecision++
+
+    if (absValue < 1/Math.pow(10, realPrecision)) {
+        do {
+            realPrecision++;
+        } while (absValue < 1/Math.pow(10, realPrecision))
+
+        realPrecision += minPrecision - 1
+    } else {
+        realPrecision = minPrecision
     }
-    if (realPrecision < minPrecision) {
-        realPrecision = minPrecision;
-    }
+
     return realPrecision;
 }

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -78,20 +78,20 @@ export function round(value:number, precision:number) {
 /**
  * Calculates a floating precision if the value is smaller than the requested precision
  * @param value The given value
- * @param precision Target precision
+ * @param minPrecision Minimal precision value
  * @return Fitting precision
  */
-export function calcFloatingPrecision(value:number, precision:number) {
-    if (precision <= 0) {
+export function calcFloatingPrecision(value:number, minPrecision:number) {
+    if (minPrecision <= 0) {
         return 0
     }
-    let realPrecision = precision;
+    let realPrecision = minPrecision;
     const absValue = Math.abs(value);
-    while (absValue > 0 && absValue < 1/Math.pow(10, realPrecision)) {
-        realPrecision += precision;
+    while (absValue > 0 && absValue < 1/Math.pow(10, Math.max(realPrecision-1, 1))) {
+        realPrecision++
     }
-    if (realPrecision < precision) {
-        realPrecision = precision;
+    if (realPrecision < minPrecision) {
+        realPrecision = minPrecision;
     }
     return realPrecision;
 }

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -98,7 +98,7 @@ export function calcDecimalPlace(value: number, minPrecision: number) {
     let realPrecision = 1;
     const absValue = Math.abs(value);
 
-    if (absValue < 1/Math.pow(10, realPrecision)) {
+    if (absValue > 0 && absValue < 1/Math.pow(10, realPrecision)) {
         do {
             realPrecision++;
         } while (absValue < 1/Math.pow(10, realPrecision))

--- a/src/value-converters/README.md
+++ b/src/value-converters/README.md
@@ -68,11 +68,12 @@ Formats a number to a given currency and a precision. If the number is smaller a
 
 **Template**
 ```html
-<span>${amount|currency:'EUR':3}</span>
+<span>${yourNumber|currency[:currency[:precision[:fixedPrecision]]]}</span>
 ```
 Examples:
 * `${0.0055|currency:"EUR":2}` -> `0,0055 €`
 * `${0.036|currency:"USD":2}` -> `$ 0,04`
+* `${0.0036|currency:"USD":2:true}` -> `$ 0,00`
 
 ## date-format-value-converter (`@deprecated`)
 
@@ -187,7 +188,7 @@ export class ViewModel {
 
 ## percent-value-converter
 ```html
-<span>${number|percent}</span>
+<span>${yourNumber|percent}</span>
 ```
 
 ## repeat-string-value-converter
@@ -219,5 +220,5 @@ Reverse an array
 
 ## number-value-converter
 ```html
-<span>${number|number:2}</span>
+<span>${yourNumber|number[:precision[:fixedPrecision]]}</span>
 ```

--- a/src/value-converters/currency-value-converter.ts
+++ b/src/value-converters/currency-value-converter.ts
@@ -5,15 +5,15 @@
  */
 import {autoinject} from "aurelia-dependency-injection";
 import {AbstractLocaleValueConverter} from "./abstract-locale-value-converter";
-import {calcFloatingPrecision} from "../utils/numbers";
+import {calcDecimalPlace} from "../utils/numbers";
 
 @autoinject()
 export class CurrencyValueConverter extends AbstractLocaleValueConverter {
 
-    toView(value:number, currencyCode:string, precision:number=2): string {
+    toView(value:number, currencyCode:string, precision:number=2, fixedPrecision:boolean = false): string {
         const options:Intl.NumberFormatOptions = {
             minimumFractionDigits: precision,
-            maximumFractionDigits: calcFloatingPrecision(value, precision),
+            maximumFractionDigits: fixedPrecision?precision:calcDecimalPlace(value, precision),
         }
 
         if (currencyCode) {

--- a/src/value-converters/number-value-converter.ts
+++ b/src/value-converters/number-value-converter.ts
@@ -5,14 +5,14 @@
  */
 import {autoinject} from "aurelia-dependency-injection";
 import {AbstractLocaleValueConverter} from "./abstract-locale-value-converter";
-import {calcFloatingPrecision} from "../utils/numbers";
+import {calcDecimalPlace} from "../utils/numbers";
 
 @autoinject()
 export class NumberValueConverter extends AbstractLocaleValueConverter {
 
     toView(value:number, precision:number=2, fixedPrecision:boolean = true): string {
         return new Intl.NumberFormat(this.getLocale(),{
-            maximumFractionDigits: fixedPrecision?precision:calcFloatingPrecision(value, precision)
+            maximumFractionDigits: fixedPrecision?precision:calcDecimalPlace(value, precision)
         }).format(value);
     }
 }

--- a/tests/utils/numbers.test.ts
+++ b/tests/utils/numbers.test.ts
@@ -125,13 +125,36 @@ const roundData = [
 ];
 
 describe.each(roundData)('round', (data) => {
-  it(`round '${data.input}/${data.precision}'`, () => {
+  it(`'${data.input}/${data.precision}'`, () => {
     expect(round(data.input, data.precision)).toEqual(data.expected);
   });
 });
 
-test("calcFloatingPointPrecision", () => {
-  const value = 0.000123
-  const precision = calcFloatingPrecision(value, 3)
-  expect(precision).toBe(6)
-})
+
+const precisionData = [
+  {
+    input: 0.000123,
+    expected: 5,
+  },
+  {
+    input: 0.0137,
+    expected: 3,
+  },
+  {
+    input: 0.137,
+    expected: 2,
+  },
+];
+
+describe.each(precisionData)('calcFloatingPointPrecision', (data) => {
+  it(`'${data.input}'`, () => {
+    expect(calcFloatingPrecision(data.input, 2)).toEqual(data.expected);
+  });
+});
+
+//
+// test("calcFloatingPointPrecision", () => {
+//   const value = 0.000123
+//   const precision = calcFloatingPrecision(value, 3)
+//   expect(precision).toBe(6)
+// })

--- a/tests/utils/numbers.test.ts
+++ b/tests/utils/numbers.test.ts
@@ -162,6 +162,11 @@ const precisionData = [
     precision: 1,
     expected: 1,
   },
+  {
+    input: 0,
+    precision: 2,
+    expected: 2,
+  },
 ];
 
 describe.each(precisionData)('calcFloatingPointPrecision', (data) => {

--- a/tests/utils/numbers.test.ts
+++ b/tests/utils/numbers.test.ts
@@ -151,10 +151,3 @@ describe.each(precisionData)('calcFloatingPointPrecision', (data) => {
     expect(calcFloatingPrecision(data.input, 2)).toEqual(data.expected);
   });
 });
-
-//
-// test("calcFloatingPointPrecision", () => {
-//   const value = 0.000123
-//   const precision = calcFloatingPrecision(value, 3)
-//   expect(precision).toBe(6)
-// })

--- a/tests/utils/numbers.test.ts
+++ b/tests/utils/numbers.test.ts
@@ -1,4 +1,4 @@
-import {bytesMap, calcFloatingPrecision, getFactor, kiloMap, round} from "../../src/utils/numbers";
+import {bytesMap, calcDecimalPlace, getFactor, kiloMap, round} from "../../src/utils/numbers";
 
 const bytesData = [
   {
@@ -134,20 +134,38 @@ describe.each(roundData)('round', (data) => {
 const precisionData = [
   {
     input: 0.000123,
+    precision: 2,
     expected: 5,
   },
   {
     input: 0.0137,
+    precision: 2,
     expected: 3,
   },
   {
     input: 0.137,
+    precision: 2,
     expected: 2,
+  },
+  {
+    input: 0.000123,
+    precision: 3,
+    expected: 6,
+  },
+  {
+    input: 0.0137,
+    precision: 1,
+    expected: 2,
+  },
+  {
+    input: 0.137,
+    precision: 1,
+    expected: 1,
   },
 ];
 
 describe.each(precisionData)('calcFloatingPointPrecision', (data) => {
   it(`'${data.input}'`, () => {
-    expect(calcFloatingPrecision(data.input, 2)).toEqual(data.expected);
+    expect(calcDecimalPlace(data.input, data.precision)).toEqual(data.expected);
   });
 });

--- a/tests/value-converters/currency-value-converter.test.ts
+++ b/tests/value-converters/currency-value-converter.test.ts
@@ -37,7 +37,7 @@ const testData = [
         value: 0.0137,
         precision: 2,
         currency: "usd",
-        expected: '$0.013'
+        expected: '$0.014'
     },
 ];
 

--- a/tests/value-converters/currency-value-converter.test.ts
+++ b/tests/value-converters/currency-value-converter.test.ts
@@ -33,6 +33,12 @@ const testData = [
         currency: "usd",
         expected: '$0.0037'
     },
+    {
+        value: 0.0137,
+        precision: 2,
+        currency: "usd",
+        expected: '$0.013'
+    },
 ];
 
 describe.each(testData)(`toView`, (data) => {


### PR DESCRIPTION
This PR provides more test samples for `calcDecimalPlace()` and add support for fixed precision on the currency value formatter the same way like number value formatter.

Update documentation and usage examples.